### PR TITLE
Add quotes to the darknet curl usage example

### DIFF
--- a/plugins/cpu-only/darknet.py
+++ b/plugins/cpu-only/darknet.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
   #  x indicates a currently ignored parameter
   #
   # Usage example:
-  #   curl http://localhost:5252/detect?kind=json&url=http%3A%2F%2Frestcam
+  #   curl "http://localhost:5252/detect?kind=json&url=http%3A%2F%2Frestcam"
   #
   @webapp.route("/detect", methods=['GET'])
   def get_detect():

--- a/plugins/cuda/darknet.py
+++ b/plugins/cuda/darknet.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
   #  x indicates a currently ignored parameter
   #
   # Usage example:
-  #   curl http://localhost:5252/detect?kind=json&url=http%3A%2F%2Frestcam
+  #   curl "http://localhost:5252/detect?kind=json&url=http%3A%2F%2Frestcam"
   #
   @webapp.route("/detect", methods=['GET'])
   def get_detect():


### PR DESCRIPTION
While testing out the `cpu-only` service, I realized that when trying out the curl command from Mac Terminal after starting the container that only the first request argument was being passed through. This is because the "&" in the command line runs the preceding command in the background, so everything after that character is cut off. More context [here](https://stackoverflow.com/questions/10978474/appending-multiple-querystring-variables-with-curl). Adding the quotes means that both arguments will get passed through.

Tested in Mac Terminal. I believe this should have no effect in Linux terminal.

Signed-off-by: Clement Ng <clementdng@gmail.com>