### PR TITLE
Change the suggested HTTP image URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Optionally configure an INPUT_URL in your environment. You have 3 choices:
 #   1. Don't set it and the "restcam" service or a static image will be used
 #   2. Provide a valid HTTP image URL. E.g.:
-#          https://commons.wikimedia.org/wiki/File:Example.jpg
+#          https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Einstein_1921_by_F_Schmutzer_-_restoration.jpg/780px-Einstein_1921_by_F_Schmutzer_-_restoration.jpg
 #   3. Provide a valid RTSP stream URL. E.g.:
 #           rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 #

--- a/achatina/Makefile
+++ b/achatina/Makefile
@@ -33,7 +33,7 @@ SERVICE_VERSION:="2.0.0"
 # Optionally configure an INPUT_URL in your environment. You have 3 choices:
 #   1. Don't set it and the restcam service or a static image will be used
 #   2. Provide a valid HTTP image URL. E.g.:
-#          https://commons.wikimedia.org/wiki/File:Example.jpg
+#          https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Einstein_1921_by_F_Schmutzer_-_restoration.jpg/780px-Einstein_1921_by_F_Schmutzer_-_restoration.jpg
 #   3. Provide a valid RTSP stream URL. E.g.:
 #           rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 


### PR DESCRIPTION
While investigating achatina (the service located in the `achatina/achatina` directory), I discovered that setting the env variable `INPUT_URL` to the suggested URL, `https://commons.wikimedia.org/wiki/File:Example.jpg`, would crash the `cpu-only` container and not return a 200. Digging into this error further, I discovered that the image written into `tmp/incoming.jpg` for `cpu-only` had text output as well, since https://commons.wikimedia.org/wiki/File:Example.jpg directs to a page with text and an image. 

While I'm not sure what the `libdarknet.so#load_image_color` method exactly calls, I would reason that any image passed through should also be able to be processed with PILLOW's `Image.open` method. However, the existing image would crash PILLOW's `Image.open` with an `IOError: cannot identify image file '/tmp/incoming.jpg'`. Since most image links should only have the image itself, I think it's better to change the image url to match a more typical link that only has the image itself ie https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg.

Tested that setting the `INPUT_URL` with normal images like https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg and https://raw.githubusercontent.com/MegaMosquito/achatina/master/shared/restcam/mock.jpg would return 200s for the `cpu-only` service when starting the achatina container with `make run`.

Signed-off-by: Clement Ng <clementdng@gmail.com>