### PR TITLE
Make achatina multistage build by copying over pdouble16/kafkacat docker image and removing packages to build kafkatools

### DIFF
--- a/achatina/Dockerfile.amd64
+++ b/achatina/Dockerfile.amd64
@@ -2,18 +2,12 @@ FROM python:3.7-alpine
 
 RUN apk update && apk add --no-cache \
   bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
   mosquitto-clients \
   jq \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over kafkatools installation
+COPY --from=pdouble16/kafkacat:1.4.0-r1 /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests

--- a/achatina/Dockerfile.arm64
+++ b/achatina/Dockerfile.arm64
@@ -2,18 +2,12 @@ FROM python:3.7-alpine
 
 RUN apk update && apk add --no-cache \
   bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
   mosquitto-clients \
   jq \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over kafkatools installation
+COPY --from=pdouble16/kafkacat:1.4.0-r1 /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests


### PR DESCRIPTION
The [docker image](https://hub.docker.com/r/pdouble16/kafkacat) I'm copying from has an Apache software license, so I believe these should be [compatible](https://www.quora.com/Can-I-use-Apache-licensed-source-code-and-redistribute-it-as-MIT-license).

Image size for `achatina/achatina` for `amd64` went from 607 MB to 55.2 MB.

Signed-off-by: Clement Ng <clementdng@gmail.com>