### PR TITLE
Make achatina multistage build by creating base and kafka_build stage

### DIFF
--- a/achatina/Dockerfile.amd64
+++ b/achatina/Dockerfile.amd64
@@ -1,19 +1,25 @@
-FROM python:3.7-alpine
-
+FROM python:3.7-alpine as base
 RUN apk update && apk add --no-cache \
-  bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
+  bash
+
+FROM base as kafka_build
+RUN apk add --no-cache \
+  curl \
+  git \
+  build-base \
+  coreutils
+
+# Build and install kafka tools
+RUN git clone -b 1.4.0 --single-branch https://github.com/edenhill/kafkacat.git && cd kafkacat && bash ./bootstrap.sh && make install && strip /usr/local/bin/kafkacat
+
+FROM base
+RUN apk add --no-cache \
   mosquitto-clients \
   jq \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over the kafka installation
+COPY --from=kafka_build /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests

--- a/achatina/Dockerfile.arm64
+++ b/achatina/Dockerfile.arm64
@@ -1,19 +1,25 @@
-FROM python:3.7-alpine
-
+FROM python:3.7-alpine as base
 RUN apk update && apk add --no-cache \
-  bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
+  bash
+
+FROM base as kafka_build
+RUN apk add --no-cache \
+  curl \
+  git \
+  build-base \
+  coreutils
+
+# Build and install kafka tools
+RUN git clone -b 1.4.0 --single-branch https://github.com/edenhill/kafkacat.git && cd kafkacat && bash ./bootstrap.sh && make install && strip /usr/local/bin/kafkacat
+
+FROM base
+RUN apk add --no-cache \
   mosquitto-clients \
   jq \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over the kafka installation
+COPY --from=kafka_build /usr/local/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests


### PR DESCRIPTION
Image size for `achatina/achatina` for `amd64` went from 607 MB to 55.8 MB, with a lot of the reduction coming from eliminating the unneeded packages in the final stage. Additionally, some space is saved by extracting out the `base` first stage.

Signed-off-by: Clement Ng <clementdng@gmail.com>