### PR TITLE
Make achatina multistage build by copying from kafkacat official image

### DIFF
--- a/achatina/Dockerfile.amd64
+++ b/achatina/Dockerfile.amd64
@@ -1,19 +1,14 @@
 FROM python:3.7-alpine
 
 RUN apk update && apk add --no-cache \
-  bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
   mosquitto-clients \
   jq \
+  librdkafka \
+  yajl \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over the kafka installation
+COPY --from=edenhill/kafkacat:1.6.0 /usr/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests

--- a/achatina/Dockerfile.arm
+++ b/achatina/Dockerfile.arm
@@ -4,7 +4,6 @@ RUN apk update && apk add --no-cache \
   bash \
   mosquitto-clients \
   python3 \
-  curl \
   jq \
   && rm -fr /tmp/*
 

--- a/achatina/Dockerfile.arm64
+++ b/achatina/Dockerfile.arm64
@@ -1,19 +1,14 @@
 FROM python:3.7-alpine
 
 RUN apk update && apk add --no-cache \
-  bash \
-  alpine-sdk \
-  cmake \
-  curl-dev \
-  bsd-compat-headers \
-  perl \
   mosquitto-clients \
   jq \
+  librdkafka \
+  yajl \
   && rm -fr /tmp/*
 
-# Build and install kafka tools (should really use a 2-stage docker build here)
-RUN curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh
-RUN make -C /kafkacat-master bin-install
+# Copy over the kafka installation
+COPY --from=edenhill/kafkacat:1.6.0 /usr/bin/kafkacat /usr/local/bin/kafkacat
 
 # Install requests (REST API client)
 RUN pip install requests


### PR DESCRIPTION
Image size for `achatina/achatina` for `amd64` went from 607 MB to 68 MB, with a lot of the reduction coming from eliminating the unneeded packages. Added packages in order to make the copied over `kafkacat` executable work. I also eliminated the `curl` package because it's not needed for the `arm` Dockerfile.

Made sure all Dockerfiles can still build.

Signed-off-by: Clement Ng <clementdng@gmail.com>