### PR TITLE
Fix JS hyphen error in rendering monitor times

### DIFF
--- a/shared/monitor/monitor.py
+++ b/shared/monitor/monitor.py
@@ -123,8 +123,8 @@ if __name__ == '__main__':
       '         const j = await response.json();\n' + \
       '         var when = new Date(j.detect.date * 1000);\n' +\
       '         var c = j.detect.entities.length;\n' +\
-      '         var ct = j.detect.cam-time;\n' +\
-      '         var it = j.detect.inf-time;\n' +\
+      '         var ct = j["detect"]["cam-time"];\n' +\
+      '         var it = j["detect"]["inf-time"];\n' +\
       '         d_date.innerHTML = when;\n' +\
       '         d_classes.innerHTML = c;\n' +\
       '         d_camtime.innerHTML = ct;\n' +\


### PR DESCRIPTION
Fixes #74 

We need to use bracket syntax for Javascript variables with hyphens in them.

Signed-off-by: Clement Ng <clementdng@gmail.com>