### PR TITLE
Add multistage build for cpu-only amd64 darknet

### DIFF
--- a/plugins/cpu-only/Dockerfile.amd64
+++ b/plugins/cpu-only/Dockerfile.amd64
@@ -1,11 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as darknet
 
 # Install build tools
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git make g++ python-pip python-setuptools python-dev zlib1g-dev libjpeg-dev wget curl jq
-
-# Required libraries
-RUN pip install wheel
-RUN pip install flask requests pillow
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git make g++ && rm -rf /var/lib/apt/lists/*
 
 # Download and build the latest darknet
 WORKDIR /
@@ -13,18 +9,31 @@ RUN git clone https://github.com/pjreddie/darknet
 WORKDIR /darknet
 RUN make
 
-# Get YOLO cfg and weights files
-WORKDIR /darknet
-RUN wget -O yolo-tiny.cfg https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov2-tiny.cfg 
-RUN wget -O yolo-tiny.weights https://pjreddie.com/media/files/yolov2-tiny.weights
+FROM ubuntu:bionic
+
+COPY --from=darknet /darknet/darknet /darknet/darknet
+COPY --from=darknet /darknet/libdarknet.a /darknet/libdarknet.a
+COPY --from=darknet /darknet/libdarknet.so /darknet/libdarknet.so
+COPY --from=darknet /darknet/cfg/coco.data /darknet/cfg/coco.data
+COPY --from=darknet /darknet/cfg/yolov3-tiny.cfg /darknet/cfg/yolov3-tiny.cfg
+COPY --from=darknet /darknet/data/coco.names /darknet/data/coco.names
+
+RUN apt-get update && apt-get install -y --no-install-recommends python-pip python-setuptools python-dev zlib1g-dev libjpeg-dev wget curl jq && rm -rf /var/lib/apt/lists/*
+
+# Required libraries
+RUN pip install wheel
+RUN pip install flask requests pillow
 
 # Copy over the logo(s)
+WORKDIR /darknet
 COPY logo.png /
 
 # Copy over the darknet and webserver code
 COPY darknet.py /
 
 # Startup the daemon
-WORKDIR /darknet
-CMD python /darknet.py yolo-tiny.cfg yolo-tiny.weights cfg/coco.data
 
+# Get YOLO weights file
+RUN wget -O yolo-tiny.weights https://pjreddie.com/media/files/yolov3-tiny.weights
+
+CMD python /darknet.py cfg/yolov3-tiny.cfg yolo-tiny.weights cfg/coco.data


### PR DESCRIPTION
Partially addresses #23. Tested that cpu-only works on my Mac when visiting this link: http://localhost:5252/detect?url=http%3A%2F%2Fraw.githubusercontent.com/MegaMosquito/achatina/master/shared/restcam/mock.jpg

Size of the build went from 491 MB => 235 MB

Signed-off-by: Clement Ng <clementdng@gmail.com>