### PR TITLE
Add multistage build for cpu-only arm64 darknet

### DIFF
--- a/plugins/cpu-only/Dockerfile.arm64
+++ b/plugins/cpu-only/Dockerfile.arm64
@@ -1,11 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as darknet
 
 # Install build tools
-RUN apt-get update && apt-get install -y --no-install-recommends git make g++ python-pip python-setuptools python-dev zlib1g-dev libjpeg-dev wget curl jq
-
-# Required libraries
-RUN pip install wheel
-RUN pip install flask requests pillow
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git make g++ && rm -rf /var/lib/apt/lists/*
 
 # Download and build the latest darknet
 WORKDIR /
@@ -13,18 +9,32 @@ RUN git clone https://github.com/pjreddie/darknet
 WORKDIR /darknet
 RUN make
 
-# Get YOLO cfg and weights files
-WORKDIR /darknet
-RUN wget -O yolo-tiny.cfg https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov2-tiny.cfg 
-RUN wget -O yolo-tiny.weights https://pjreddie.com/media/files/yolov2-tiny.weights
+FROM ubuntu:bionic
+
+COPY --from=darknet /darknet/darknet /darknet/darknet
+COPY --from=darknet /darknet/libdarknet.a /darknet/libdarknet.a
+COPY --from=darknet /darknet/libdarknet.so /darknet/libdarknet.so
+COPY --from=darknet /darknet/cfg/coco.data /darknet/cfg/coco.data
+COPY --from=darknet /darknet/cfg/yolov2-tiny.cfg /darknet/cfg/yolov2-tiny.cfg
+COPY --from=darknet /darknet/data/coco.names /darknet/data/coco.names
+
+RUN apt-get update && apt-get install -y --no-install-recommends python-pip python-setuptools python-dev zlib1g-dev libjpeg-dev wget curl jq && rm -rf /var/lib/apt/lists/*
+
+# Required libraries
+RUN pip install wheel
+RUN pip install flask requests pillow
 
 # Copy over the logo(s)
+WORKDIR /darknet
 COPY logo.png /
 
 # Copy over the darknet and webserver code
 COPY darknet.py /
 
 # Startup the daemon
-WORKDIR /darknet
-CMD python /darknet.py yolo-tiny.cfg yolo-tiny.weights cfg/coco.data
+
+# Get YOLO weights file
+RUN wget -O yolo-tiny.weights https://pjreddie.com/media/files/yolov2-tiny.weights
+
+CMD python /darknet.py cfg/yolov2-tiny.cfg yolo-tiny.weights cfg/coco.data
 


### PR DESCRIPTION
Partially addresses #23. Based on the changes introduced to the `amd64` build. Wasn't able to test this since I wasn't able to reflash my Pi.

Signed-off-by: Clement Ng <clementdng@gmail.com>